### PR TITLE
added Cargo.lock, fixes #10

### DIFF
--- a/hw0/task2/README.md
+++ b/hw0/task2/README.md
@@ -8,6 +8,7 @@
 
     ```text
     task2
+    ├── Cargo.lock
     ├── Cargo.toml
     └── src
         └── main.rs


### PR DESCRIPTION
Because we no longer ignore `Cargo.lock`.